### PR TITLE
Feature/notice domain

### DIFF
--- a/src/main/java/syboo/notice/notice/domain/Notice.java
+++ b/src/main/java/syboo/notice/notice/domain/Notice.java
@@ -1,0 +1,106 @@
+package syboo.notice.notice.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import syboo.notice.common.domain.baseentity.BaseEntity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notices", indexes = {
+        @Index(name = "idx_notice_created_at", columnList = "createdAt"),
+        @Index(name = "idx_notice_title", columnList = "title")
+})
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private String author;
+
+    @Column(nullable = false)
+    private LocalDateTime noticeStartAt;
+
+    @Column(nullable = false)
+    private LocalDateTime noticeEndAt;
+
+    @Column(nullable = false)
+    private long viewCount = 0L;
+
+    @Version
+    private Long version;
+
+    @OneToMany(mappedBy = "notice",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    private final List<NoticeAttachment> attachments = new ArrayList<>();
+
+    @Builder
+    private Notice(
+            String title,
+            String content,
+            String author,
+            LocalDateTime noticeStartAt,
+            LocalDateTime noticeEndAt
+    ) {
+        validateNoticePeriod(noticeStartAt, noticeEndAt);
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.noticeStartAt = noticeStartAt;
+        this.noticeEndAt = noticeEndAt;
+    }
+
+    public void update(
+            String title,
+            String content,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
+        validateNoticePeriod(startAt, endAt);
+        this.title = title;
+        this.content = content;
+        this.noticeStartAt = startAt;
+        this.noticeEndAt = endAt;
+    }
+
+    private void validateNoticePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        if (endAt.isBefore(startAt)) {
+            throw new IllegalArgumentException("공지 종료일은 시작일보다 빠를 수 없습니다.");
+        }
+    }
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void addAttachment(NoticeAttachment attachment) {
+        attachments.add(attachment);
+        attachment.assignNotice(this);
+    }
+
+    public void removeAttachment(NoticeAttachment attachment) {
+        attachments.remove(attachment);
+        attachment.assignNotice(null);
+    }
+
+    public void removeAllAttachments() {
+        attachments.clear();
+    }
+}

--- a/src/main/java/syboo/notice/notice/domain/NoticeAttachment.java
+++ b/src/main/java/syboo/notice/notice/domain/NoticeAttachment.java
@@ -1,0 +1,42 @@
+package syboo.notice.notice.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notice_attachments")
+public class NoticeAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String storedPath;
+
+    @Column(nullable = false)
+    private long fileSize;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Builder
+    private NoticeAttachment(String fileName, String storedPath, long fileSize) {
+        this.fileName = fileName;
+        this.storedPath = storedPath;
+        this.fileSize = fileSize;
+    }
+
+    void assignNotice(Notice notice) {
+        this.notice = notice;
+    }
+}

--- a/src/test/java/syboo/notice/notice/domain/NoticeTest.java
+++ b/src/test/java/syboo/notice/notice/domain/NoticeTest.java
@@ -1,0 +1,138 @@
+package syboo.notice.notice.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NoticeTest {
+    @Test
+    void create_notice_success() {
+        // given
+        LocalDateTime startAt = LocalDateTime.now();
+        LocalDateTime endAt = startAt.plusDays(1);
+
+        // when
+        Notice notice = Notice.builder()
+                .title("title")
+                .content("content")
+                .author("admin")
+                .noticeStartAt(startAt)
+                .noticeEndAt(endAt)
+                .build();
+
+        // then
+        assertThat(notice.getTitle()).isEqualTo("title");
+        assertThat(notice.getViewCount()).isZero();
+    }
+
+    @Test
+    void create_notice_fail_when_end_before_start() {
+        // given
+        LocalDateTime startAt = LocalDateTime.now();
+        LocalDateTime endAt = startAt.minusDays(1);
+
+        // when & then
+        assertThatThrownBy(() ->
+                Notice.builder()
+                        .title("title")
+                        .content("content")
+                        .author("admin")
+                        .noticeStartAt(startAt)
+                        .noticeEndAt(endAt)
+                        .build()
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void update_notice_success() {
+        // given
+        Notice notice = createNotice();
+
+        // when
+        notice.update(
+                "new title",
+                "new content",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1)
+        );
+
+        // then
+        assertThat(notice.getTitle()).isEqualTo("new title");
+    }
+
+    @Test
+    void increase_view_count() {
+        // given
+        Notice notice = createNotice();
+
+        // when
+        notice.increaseViewCount();
+        notice.increaseViewCount();
+
+        // then
+        assertThat(notice.getViewCount()).isEqualTo(2);
+    }
+
+    @Test
+    void add_attachment() {
+        // given
+        Notice notice = createNotice();
+        NoticeAttachment attachment = createAttachment();
+
+        // when
+        notice.addAttachment(attachment);
+
+        // then
+        assertThat(notice.getAttachments()).hasSize(1);
+    }
+
+    @Test
+    void remove_attachment() {
+        // given
+        Notice notice = createNotice();
+        NoticeAttachment attachment = createAttachment();
+        notice.addAttachment(attachment);
+
+        // when
+        notice.removeAttachment(attachment);
+
+        // then
+        assertThat(notice.getAttachments()).isEmpty();
+    }
+
+    @Test
+    void remove_all_attachments() {
+        // given
+        Notice notice = createNotice();
+        notice.addAttachment(createAttachment());
+        notice.addAttachment(createAttachment());
+
+        // when
+        notice.removeAllAttachments();
+
+        // then
+        assertThat(notice.getAttachments()).isEmpty();
+    }
+
+    private Notice createNotice() {
+        return Notice.builder()
+                .title("title")
+                .content("content")
+                .author("admin")
+                .noticeStartAt(LocalDateTime.now())
+                .noticeEndAt(LocalDateTime.now().plusDays(1))
+                .build();
+    }
+
+    private NoticeAttachment createAttachment() {
+        return NoticeAttachment.builder()
+                .fileName("file.txt")
+                .storedPath("/files/file.txt")
+                .fileSize(100L)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🔎 작업 개요
- 공지사항(Notice) 도메인 엔티티를 Aggregate Root로 설계하였습니다.
- 공지사항에 종속된 첨부파일(NoticeAttachment)을 내부 엔티티로 구현하였습니다.
- 공지사항 도메인 규칙에 대한 단위 테스트를 작성하였습니다.

## 🎯 관련 Issue
- Close #4 
- Close #5

## 🧪 테스트
- [x] 단위 테스트 추가
- [x] 기존 테스트 통과 확인

## ⚙️ 주요 변경 사항
- Notice를 Aggregate Root로 정의하고, Attachment의 생명주기를 Notice가 관리하도록 설계
- Notice 1:N Attachment 연관관계 적용
- orphanRemoval을 통해 공지 삭제 시 첨부파일 자동 정리
- 공지 시작/종료 기간에 대한 도메인 검증 로직 추가
- 조회수 증가 로직을 도메인 메서드로 명확히 분리

## 📌 리뷰 포인트
- Attachment를 독립 도메인이 아닌 Notice Aggregate 내부 엔티티로 설계한 부분
- 도메인 로직이 엔티티 내부에 적절히 위치했는지 여부
- 단위 테스트가 도메인 규칙을 충분히 검증하는지
