### PR TITLE
#12 chore:build.gradle 정리, log4j2-spring.xml 추가/설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    // Logback 제외(log4j2 와 충돌 이슈)
+    configureEach {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
 }
 
 repositories {
@@ -48,8 +53,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 
     // 로깅
-    implementation 'org.springframework.boot:spring-boot-starter-log4j2:4.0.1'
-
+    runtimeOnly group: 'org.springframework.boot', module: 'spring-boot-starter-log4j2'
 
     //테스트에서 lombok 사용
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/log4j2-spring.xml
+++ b/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+    <Properties>
+        <Property name="LOG_PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Property>
+        <Property name="LOG_PATH">${spring:logging.path:-./logs}</Property>
+        <Property name="APP_NAME">${spring:spring.application.name:-notice-app}</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+        </Console>
+
+        <RollingFile name="FILE"
+                     fileName="${LOG_PATH}/${APP_NAME}.log"
+                     filePattern="${LOG_PATH}/${APP_NAME}-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+                <SizeBasedTriggeringPolicy size="100MB"/> </Policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath="${LOG_PATH}" maxDepth="1">
+                    <IfFileName glob="${APP_NAME}-*.log.gz" />
+                    <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="syboo.notice" level="DEBUG" additivity="false">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="FILE"/>
+        </Logger>
+
+        <Root level="INFO">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="FILE"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## 🔎 작업 개요
- Spring Boot 로깅 초기화 충돌 문제를 해결하기 위해 로깅 설정을 정리했습니다.
- Spring Boot LoggingSystem이 로깅을 제어하도록 `log4j2-spring.xml` 기반으로 전환했습니다.

## 🎯 관련 Issue
- Close #12

## ⚙️ 주요 변경 사항
- `build.gradle`에서 로깅 관련 의존성 충돌 제거
  - logback 제
  - log4j2 단일 로깅 체계로 정리
- `log4j2-spring.xml` 추가
  - Spring Environment(application.yml) 연동
  - 콘솔 + 파일 로그 설정
  - 날짜/용량 기반 로그 롤링 및 보존 정책 적용

## 🧪 검증 방법
- `./gradlew test` 실행 시 SLF4J 다중 바인딩 경고 및 LoggingException 미발생 확인
- 애플리케이션 기동 시 로그 정상 출력 확인
- 기존 서비스/테스트 코드 수정 없이 로그 사용 가능함을 확인

## 📌 리뷰 포인트
- `log4j2-spring.xml` 설정이 Spring Boot 환경에 적절한지

## ✅ 체크리스트
- [x] 로깅 충돌 문제 해결
- [x] 기존 기능 영향 없음
- [ ] README / 문서 반영 (후속 작업 예정)
