### PR TITLE
Feature/notice service

### DIFF
--- a/src/main/java/syboo/notice/notice/application/CreateNoticeCommand.java
+++ b/src/main/java/syboo/notice/notice/application/CreateNoticeCommand.java
@@ -1,0 +1,28 @@
+package syboo.notice.notice.application;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateNoticeCommand {
+
+    private String title;
+    private String content;
+    private String author;
+    private LocalDateTime noticeStartAt;
+    private LocalDateTime noticeEndAt;
+
+    private List<AttachmentCommand> attachments;
+
+    @Getter
+    @AllArgsConstructor
+    public static class AttachmentCommand {
+        private String fileName;
+        private String storedPath;
+        private long fileSize;
+    }
+}

--- a/src/main/java/syboo/notice/notice/application/NoticeService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeService.java
@@ -1,0 +1,54 @@
+package syboo.notice.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import syboo.notice.notice.domain.Notice;
+import syboo.notice.notice.domain.NoticeAttachment;
+import syboo.notice.notice.repository.NoticeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    public Long createNotice(CreateNoticeCommand command) {
+        log.info("공지사항 생성 시작: title='{}', author='{}'", command.getTitle(), command.getAuthor());
+
+        Notice notice = Notice.builder()
+                .title(command.getTitle())
+                .content(command.getContent())
+                .author(command.getAuthor())
+                .noticeStartAt(command.getNoticeStartAt())
+                .noticeEndAt(command.getNoticeEndAt())
+                .build();
+
+        processAttachments(command, notice);
+
+        Notice savedNotice = noticeRepository.save(notice);
+
+        log.info("공지사항 저장 완료: id={}", savedNotice.getId());
+        return savedNotice.getId();
+    }
+
+    private static void processAttachments(CreateNoticeCommand command, Notice notice) {
+        if (command.getAttachments() == null || command.getAttachments().isEmpty()) {
+            return;
+        }
+
+        for (CreateNoticeCommand.AttachmentCommand att : command.getAttachments()) {
+            notice.addAttachment(
+                    NoticeAttachment.builder()
+                            .fileName(att.getFileName())
+                            .storedPath(att.getStoredPath())
+                            .fileSize(att.getFileSize())
+                            .build()
+            );
+        }
+
+        log.debug("첨부파일 {}개 추가 완료", command.getAttachments().size());
+    }
+}

--- a/src/main/java/syboo/notice/notice/repository/NoticeAttachmentRepository.java
+++ b/src/main/java/syboo/notice/notice/repository/NoticeAttachmentRepository.java
@@ -1,0 +1,7 @@
+package syboo.notice.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import syboo.notice.notice.domain.NoticeAttachment;
+
+public interface NoticeAttachmentRepository extends JpaRepository<NoticeAttachment, Long> {
+}

--- a/src/main/java/syboo/notice/notice/repository/NoticeRepository.java
+++ b/src/main/java/syboo/notice/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package syboo.notice.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import syboo.notice.notice.domain.Notice;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/test/java/syboo/notice/notice/application/NoticeServiceTest.java
+++ b/src/test/java/syboo/notice/notice/application/NoticeServiceTest.java
@@ -1,0 +1,86 @@
+package syboo.notice.notice.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import syboo.notice.notice.domain.Notice;
+import syboo.notice.notice.repository.NoticeRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @Test
+    @DisplayName("공지사항 등록 성공 - 첨부파일 포함")
+    void createNotice() {
+        // given
+        CreateNoticeCommand command = new CreateNoticeCommand(
+                "공지 제목",
+                "공지 내용",
+                "admin",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                List.of()
+        );
+
+        Notice savedNotice = Notice.builder()
+                .title(command.getTitle())
+                .content(command.getContent())
+                .author(command.getAuthor())
+                .noticeStartAt(command.getNoticeStartAt())
+                .noticeEndAt(command.getNoticeEndAt())
+                .build();
+
+        ReflectionTestUtils.setField(savedNotice, "id", 1L);
+
+        given(noticeRepository.save(any(Notice.class)))
+                .willReturn(savedNotice);
+
+        // when
+        Long noticeId = noticeService.createNotice(command);
+
+        // then
+        assertThat(noticeId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("공지 종료일이 시작일보다 빠르면 실패한다")
+    void createNotice_fail_when_notice_end_before_start() {
+        // given
+        CreateNoticeCommand command = new CreateNoticeCommand(
+                "제목",
+                "내용",
+                "admin",
+                LocalDateTime.now(),
+                LocalDateTime.now().minusDays(1),
+                null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> noticeService.createNotice(command))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("공지 종료일");
+
+        // 실패 시 DB 저장이 절대 호출되지 않았음을 확인 (대용량/성능 관점)
+        verify(noticeRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 개요
- 공지사항 등록(Service) 기능을 구현했습니다.
- 첨부파일을 포함한 공지사항 생성 로직을 서비스 계층에서 처리하도록 구성했습니다.
- 공지 시작/종료 기간에 대한 도메인 규칙 검증 흐름을 포함했습니다.

## 🎯 관련 Issue
- Close #10

## 🧪 테스트
- [x] 단위 테스트 추가 (NoticeServiceTest)
- [x] 통합 테스트 추가 (추후 CRUD API 단계에서 진행)
- [x] 기존 테스트 통과 확인

## ⚙️ 주요 변경 사항
- `NoticeService#createNotice` 메서드 구현
  - Notice Aggregate 생성 및 저장
  - 첨부파일 존재 시 Notice에 연관관계 설정
- 공지 기간(startAt / endAt)에 대한 도메인 검증 로직 활용
- Repository를 Mock 처리한 Service 단위 테스트 작성
  - 정상 등록 시 ID 반환 검증
  - 잘못된 기간 입력 시 예외 발생 검증

## 📌 리뷰 포인트
- 공지사항 등록 책임을 Service 계층에서 적절히 처리하고 있는지
- 도메인 검증 로직(공지 기간 검증) 호출 위치가 적절한지
- 첨부파일 처리 방식이 과하지 않은지

## ✅ 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 영향 없음
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인 (후속 작업 예정)
