### PR TITLE
#12 chore:build.gradle 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 
     // 로깅
-    runtimeOnly group: 'org.springframework.boot', module: 'spring-boot-starter-log4j2'
+    runtimeOnly "org.springframework.boot:spring-boot-starter-log4j2"
 
     //테스트에서 lombok 사용
     testCompileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## 🔎 작업 개요
- Spring Boot 로깅 초기화 충돌 문제를 해결하기 위해 로깅 설정을 정리했습니다.

## 🎯 관련 Issue
- Close #12

## ⚙️ 주요 변경 사항
- `build.gradle`에서 로깅 관련 의존성 충돌 제거
