### PR TITLE
공지사항 수정(Update) 및 삭제(Delete) 서비스 구현 및 단위 테스트

### DIFF
--- a/src/main/java/syboo/notice/notice/application/NoticeService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeService.java
@@ -8,6 +8,8 @@ import syboo.notice.notice.domain.Notice;
 import syboo.notice.notice.domain.NoticeAttachment;
 import syboo.notice.notice.repository.NoticeRepository;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -15,9 +17,15 @@ import syboo.notice.notice.repository.NoticeRepository;
 public class NoticeService {
     private final NoticeRepository noticeRepository;
 
+    /**
+     * 신규 공지사항을 등록한다.
+     * @param command 공지사항 생성에 필요한 데이터 (DTO)
+     * @return 생성된 공지사항의 식별자(ID)
+     */
     public Long createNotice(CreateNoticeCommand command) {
         log.info("공지사항 생성 시작: title='{}', author='{}'", command.getTitle(), command.getAuthor());
 
+        // 기본 정보 생성 (내부에서 기간 검증 수행)
         Notice notice = Notice.builder()
                 .title(command.getTitle())
                 .content(command.getContent())
@@ -34,6 +42,10 @@ public class NoticeService {
         return savedNotice.getId();
     }
 
+    /**
+     * 요청 데이터로부터 첨부파일 엔티티를 생성하여 공지사항에 추가한다.
+     * CascadeType.ALL 설정에 의해 Notice 저장 시 함께 저장된다.
+     */
     private static void processAttachments(CreateNoticeCommand command, Notice notice) {
         if (command.getAttachments() == null || command.getAttachments().isEmpty()) {
             return;
@@ -50,5 +62,66 @@ public class NoticeService {
         }
 
         log.debug("첨부파일 {}개 추가 완료", command.getAttachments().size());
+    }
+
+    /**
+     * 공지사항 정보를 수정한다.
+     * <p>
+     * JPA의 변경 감지(Dirty Checking) 기능을 활용하여, 엔티티의 상태 변경만으로
+     * 트랜잭션 종료 시점에 업데이트 쿼리가 수행된다.
+     * 첨부파일의 경우 기존 리스트를 비우고 새로 등록하는 전체 교체 방식을 사용한다.
+     *
+     * @param noticeId 수정할 공지사항의 식별자
+     * @param command  수정할 데이터가 담긴 Command 객체
+     * @throws IllegalArgumentException 존재하지 않는 ID이거나 공지 기간 유효성 검증 실패 시 발생
+     */
+    public void updateNotice(Long noticeId, UpdateNoticeCommand command) {
+        log.info("공지사항 수정 시작: id={}, title='{}'", noticeId, command.getTitle());
+
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> {
+                    log.error("공지사항 수정 실패: 존재하지 않는 ID = {}", noticeId);
+                    return new IllegalArgumentException("공지사항이 존재하지 않습니다.");
+                });
+
+        // 기본 정보 수정 (내부에서 기간 검증 수행)
+        notice.update(
+                command.getTitle(),
+                command.getContent(),
+                command.getNoticeStartAt(),
+                command.getNoticeEndAt()
+        );
+
+        updateAttachments(notice, command.getAttachments());
+
+        log.info("공지사항 수정 완료: id={}", noticeId);
+        // @Transactional에 의해 별도의 save() 호출 없이도 변경사항이 DB에 반영(Dirty Checking)됩니다.
+    }
+
+    /**
+     * 첨부파일 리스트를 교체한다.
+     * <p>
+     * orphanRemoval = true 설정에 의해 기존 attachments 리스트를 clear() 하면
+     * 기존 데이터는 DB에서 자동으로 DELETE 된다.
+     *
+     * @param notice             수정할 공지사항 엔티티
+     * @param attachmentCommands 새롭게 등록할 첨부파일 정보 리스트
+     */
+    private void updateAttachments(Notice notice, List<UpdateNoticeCommand.AttachmentCommand> attachmentCommands) {
+        // 기존 첨부파일 전체 제거 (orphanRemoval = true에 의해 DB에서도 삭제됨)
+        notice.removeAllAttachments();
+
+        if (attachmentCommands != null && !attachmentCommands.isEmpty()) {
+            for (UpdateNoticeCommand.AttachmentCommand att : attachmentCommands) {
+                notice.addAttachment(
+                        NoticeAttachment.builder()
+                                .fileName(att.getFileName())
+                                .storedPath(att.getStoredPath())
+                                .fileSize(att.getFileSize())
+                                .build()
+                );
+            }
+            log.debug("첨부파일 교체 완료: {}개 신규 등록", attachmentCommands.size());
+        }
     }
 }

--- a/src/main/java/syboo/notice/notice/application/NoticeService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeService.java
@@ -124,4 +124,27 @@ public class NoticeService {
             log.debug("첨부파일 교체 완료: {}개 신규 등록", attachmentCommands.size());
         }
     }
+
+    /**
+     * 공지사항을 삭제한다.
+     * <p>
+     * {@link CascadeType#ALL} 및 {@code orphanRemoval = true} 설정에 의해
+     * 해당 공지사항과 연관된 모든 첨부파일(NoticeAttachment) 데이터도 함께 삭제된다.
+     *
+     * @param noticeId 삭제할 공지사항의 식별자
+     * @throws IllegalArgumentException 존재하지 않는 ID일 경우 발생
+     */
+    public void deleteNotice(Long noticeId) {
+        log.info("공지사항 삭제 요청: id={}", noticeId);
+
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> {
+                    log.error("공지사항 삭제 실패: 존재하지 않는 ID = {}", noticeId);
+                    return new IllegalArgumentException("공지사항이 존재하지 않습니다.");
+                });
+
+        noticeRepository.delete(notice);
+
+        log.info("공지사항 삭제 완료: id={}", noticeId);
+    }
 }

--- a/src/main/java/syboo/notice/notice/application/UpdateNoticeCommand.java
+++ b/src/main/java/syboo/notice/notice/application/UpdateNoticeCommand.java
@@ -1,0 +1,27 @@
+package syboo.notice.notice.application;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateNoticeCommand {
+
+    private final Long noticeId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime noticeStartAt;
+    private final LocalDateTime noticeEndAt;
+    private final List<AttachmentCommand> attachments;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class AttachmentCommand {
+        private final String fileName;
+        private final String storedPath;
+        private final long fileSize;
+    }
+}

--- a/src/test/java/syboo/notice/notice/application/NoticeServiceTest.java
+++ b/src/test/java/syboo/notice/notice/application/NoticeServiceTest.java
@@ -12,6 +12,7 @@ import syboo.notice.notice.repository.NoticeRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -83,4 +84,118 @@ class NoticeServiceTest {
         // 실패 시 DB 저장이 절대 호출되지 않았음을 확인 (대용량/성능 관점)
         verify(noticeRepository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("공지사항 수정 성공 - 첨부파일 포함")
+    void updateNotice_success() {
+        // given
+        Long noticeId = 1L;
+
+        Notice notice = Notice.builder()
+                .title("기존 제목")
+                .content("기존 내용")
+                .author("admin")
+                .noticeStartAt(LocalDateTime.now())
+                .noticeEndAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        ReflectionTestUtils.setField(notice, "id", noticeId);
+
+        given(noticeRepository.findById(noticeId))
+                .willReturn(Optional.of(notice));
+
+        UpdateNoticeCommand command = new UpdateNoticeCommand(
+                noticeId,
+                "수정된 제목",
+                "수정된 내용",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(2),
+                List.of(
+                        new UpdateNoticeCommand.AttachmentCommand(
+                                "file.txt",
+                                "/files/file.txt",
+                                1024L
+                        )
+                )
+        );
+
+        // when
+        noticeService.updateNotice(noticeId, command);
+
+        // then
+        assertThat(notice.getTitle()).isEqualTo("수정된 제목");
+        assertThat(notice.getAttachments()).hasSize(1);
+
+        verify(noticeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 공지사항을 수정하면 예외가 발생한다")
+    void updateNotice_fail_whenNoticeNotFound() {
+        // given
+        Long noticeId = 999L;
+
+        given(noticeRepository.findById(noticeId))
+                .willReturn(Optional.empty());
+
+        UpdateNoticeCommand command = new UpdateNoticeCommand(
+                noticeId,
+                "제목",
+                "내용",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                List.of()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> noticeService.updateNotice(noticeId, command))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("공지사항이 존재하지 않습니다.");
+
+        verify(noticeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("공지사항을 정상적으로 삭제한다")
+    void deleteNotice_success() {
+        // given
+        Long noticeId = 1L;
+
+        Notice notice = Notice.builder()
+                .title("공지")
+                .content("내용")
+                .author("admin")
+                .noticeStartAt(LocalDateTime.now())
+                .noticeEndAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        ReflectionTestUtils.setField(notice, "id", noticeId);
+
+        given(noticeRepository.findById(noticeId))
+                .willReturn(Optional.of(notice));
+
+        // when
+        noticeService.deleteNotice(noticeId);
+
+        // then
+        verify(noticeRepository).delete(notice);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 공지사항을 삭제하면 예외가 발생한다")
+    void deleteNotice_fail_whenNoticeNotFound() {
+        // given
+        Long noticeId = 999L;
+
+        given(noticeRepository.findById(noticeId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> noticeService.deleteNotice(noticeId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("공지사항이 존재하지 않습니다.");
+
+        verify(noticeRepository, never()).delete(any());
+    }
+
 }


### PR DESCRIPTION
## 🔎 작업 개요
- 기존에 등록된 공지사항을 수정 및 삭제하는 Service 기능을 구현했습니다.
- 공지사항 수정 시 첨부파일 교체 로직을 함께 처리하도록 구현했습니다.
- 수정/삭제 흐름에 대한 Service 단위 테스트를 추가했습니다.

## 🎯 관련 Issue
- Close #11

## 🧪 테스트
- [x] 단위 테스트 추가
- [x] 통합 테스트 추가
- [x] 기존 테스트 통과 확인

## ⚙️ 주요 변경 사항
- `NoticeService#updateNotice`
  - 공지사항 기본 정보 수정
  - 공지 기간(startAt / endAt) 도메인 검증 로직 활용
  - 첨부파일 전체 교체 방식 적용(orphanRemoval 활용)
- `NoticeService#deleteNotice`
  - 공지사항 삭제 처리
  - 연관된 첨부파일 자동 삭제
- 수정/삭제 대상이 존재하지 않을 경우 예외 처리
- Repository를 Mock 처리한 Service 단위 테스트 작성

## 📌 리뷰 포인트
- 수정 시 첨부파일을 전체 교체하는 방식이 적절한지
- Service 계층에서의 예외 처리 위치가 적절한지
- 도메인 메서드(update / removeAllAttachments)의 책임 범위

## ✅ 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 영향 없음
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인
