### PR TITLE
Feature/notice service

### DIFF
--- a/src/main/java/syboo/notice/notice/api/NoticeController.java
+++ b/src/main/java/syboo/notice/notice/api/NoticeController.java
@@ -1,0 +1,74 @@
+package syboo.notice.notice.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import syboo.notice.notice.api.request.CreateNoticeRequest;
+import syboo.notice.notice.application.NoticeService;
+import syboo.notice.notice.application.command.CreateNoticeCommand;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    /**
+     * 신규 공지사항을 등록한다.
+     * * @param request 공지사항 등록 요청 데이터 (JSON)
+     * @return 생성된 공지사항의 식별자(ID)와 201 Created 상태코드
+     */
+    @PostMapping
+    public ResponseEntity<Long> createNotice(@RequestBody @Valid CreateNoticeRequest request) {
+        log.info("공지사항 등록 요청: title='{}', author='{}'", request.title(), request.author());
+
+        Long noticeId = noticeService.createNotice(toCommand(request));
+
+        // 현재 요청 URI를 기준으로 새로운 리소스의 위치를 생성 (더 안전한 방식)
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(noticeId)
+                .toUri();
+
+        log.info("공지사항 등록 완료: id={}", noticeId);
+
+        return ResponseEntity.created(location).body(noticeId);
+    }
+
+    /**
+     * Request DTO를 Command 객체로 매핑한다.
+     * 계층 간 의존성을 분리하기 위한 작업이다.
+     */
+    private CreateNoticeCommand toCommand(CreateNoticeRequest request) {
+        List<CreateNoticeCommand.AttachmentCommand> attachments =
+            Optional.ofNullable(request.attachments())
+                    .orElseGet(List::of) // null 안전성 확보
+                    .stream()
+                    .map(att -> new CreateNoticeCommand.AttachmentCommand(
+                            att.fileName(),
+                            att.storedPath(),
+                            att.fileSize()
+                    ))
+                    .toList();
+
+        log.debug("첨부파일 변환 완료: {}개", attachments.size());
+
+        return new CreateNoticeCommand(
+                request.title(),
+                request.content(),
+                request.author(),
+                request.noticeStartAt(),
+                request.noticeEndAt(),
+                attachments
+        );
+    }
+}

--- a/src/main/java/syboo/notice/notice/api/request/CreateNoticeRequest.java
+++ b/src/main/java/syboo/notice/notice/api/request/CreateNoticeRequest.java
@@ -1,0 +1,39 @@
+package syboo.notice.notice.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateNoticeRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 500, message = "제목은 최대 500자까지 입력 가능합니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        String content,
+
+        @NotBlank(message = "작성자는 필수입니다.")
+        String author,
+
+        @NotNull(message = "공지 시작일은 필수입니다.")
+        LocalDateTime noticeStartAt,
+
+        @NotNull(message = "공지 종료일은 필수입니다.")
+        LocalDateTime noticeEndAt,
+
+        List<AttachmentRequest> attachments
+) {
+    public record AttachmentRequest(
+            @NotBlank(message = "파일명은 필수입니다.")
+            String fileName,
+
+            @NotBlank(message = "저장 경로는 필수입니다.")
+            String storedPath,
+
+            long fileSize
+    ) {}
+}
+

--- a/src/main/java/syboo/notice/notice/application/NoticeService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import syboo.notice.notice.application.command.CreateNoticeCommand;
+import syboo.notice.notice.application.command.UpdateNoticeCommand;
 import syboo.notice.notice.domain.Notice;
 import syboo.notice.notice.domain.NoticeAttachment;
 import syboo.notice.notice.repository.NoticeRepository;

--- a/src/main/java/syboo/notice/notice/application/command/CreateNoticeCommand.java
+++ b/src/main/java/syboo/notice/notice/application/command/CreateNoticeCommand.java
@@ -1,4 +1,4 @@
-package syboo.notice.notice.application;
+package syboo.notice.notice.application.command;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/syboo/notice/notice/application/command/UpdateNoticeCommand.java
+++ b/src/main/java/syboo/notice/notice/application/command/UpdateNoticeCommand.java
@@ -1,4 +1,4 @@
-package syboo.notice.notice.application;
+package syboo.notice.notice.application.command;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/syboo/notice/notice/application/NoticeServiceTest.java
+++ b/src/test/java/syboo/notice/notice/application/NoticeServiceTest.java
@@ -7,6 +7,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import syboo.notice.notice.application.command.CreateNoticeCommand;
+import syboo.notice.notice.application.command.UpdateNoticeCommand;
 import syboo.notice.notice.domain.Notice;
 import syboo.notice.notice.repository.NoticeRepository;
 


### PR DESCRIPTION
## 🔎 작업 개요
- 신규 공지사항 등록 API 컨트롤러 구현
- CreateNoticeRequest DTO → CreateNoticeCommand 변환 로직 추가
- Optional 및 Null 안전성을 고려한 첨부파일 처리
- 등록 성공 시 Location 헤더 포함 201 Created 응답 반환

## 🎯 관련 Issue
- Close #10

## 🧪 테스트
- [x] NoticeService 단위 테스트 작성 완료
- [x] 컨트롤러 통합 테스트 작성 예정
- [x] 기존 서비스 단위 테스트 통과 확인

## ⚙️ 주요 변경 사항
- `NoticeController#createNotice()` 메서드 구현
- `toCommand()` 내부 매핑 로직 개선 (Optional 적용, 첨부파일 null 안전성 처리)
- 등록 요청 시 로그 기록 추가 (INFO: 제목/작성자, DEBUG: 첨부파일 개수)
- ResponseEntity.created(location).body(noticeId) 방식으로 RESTful 응답 반환

### 설계상 의사결정 포인트
- DTO와 Command 객체 분리: 계층 간 의존성 최소화
- Controller 단위 테스트는 생략, 서비스 단위 테스트로 검증
- Optional.ofNullable()을 사용하여 null attachments 처리

## 📌 리뷰 포인트
- 첨부파일 null 처리 및 매핑 로직 적절성
- RESTful ResponseEntity 반환 방식
- 로그 레벨 및 기록 정보 적절성
- DTO → Command 변환의 가독성 및 안정성

## ✅ 체크리스트
- [x] 서비스 단위 테스트 작성 완료
- [x] 컨트롤러 테스트 필요 시 추가 작성 가능
- [x] 기존 기능 영향 없음
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인
