### PR TITLE
feat: 공지사항 수정/삭제 컨트롤러 및 DTO 추가

### DIFF
--- a/src/main/java/syboo/notice/notice/api/NoticeController.java
+++ b/src/main/java/syboo/notice/notice/api/NoticeController.java
@@ -1,14 +1,17 @@
 package syboo.notice.notice.api;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import syboo.notice.notice.api.request.CreateNoticeRequest;
+import syboo.notice.notice.api.request.UpdateNoticeRequest;
 import syboo.notice.notice.application.NoticeService;
 import syboo.notice.notice.application.command.CreateNoticeCommand;
+import syboo.notice.notice.application.command.UpdateNoticeCommand;
 
 import java.net.URI;
 import java.util.List;
@@ -24,7 +27,7 @@ public class NoticeController {
 
     /**
      * 신규 공지사항을 등록한다.
-     * * @param request 공지사항 등록 요청 데이터 (JSON)
+     * @param request 공지사항 등록 요청 데이터 (JSON)
      * @return 생성된 공지사항의 식별자(ID)와 201 Created 상태코드
      */
     @PostMapping
@@ -33,11 +36,8 @@ public class NoticeController {
 
         Long noticeId = noticeService.createNotice(toCommand(request));
 
-        // 현재 요청 URI를 기준으로 새로운 리소스의 위치를 생성 (더 안전한 방식)
-        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(noticeId)
-                .toUri();
+        // 현재 요청 URI를 기준으로 새로운 리소스의 위치를 생성
+        URI location = createLocationUri(noticeId);
 
         log.info("공지사항 등록 완료: id={}", noticeId);
 
@@ -45,20 +45,68 @@ public class NoticeController {
     }
 
     /**
-     * Request DTO를 Command 객체로 매핑한다.
-     * 계층 간 의존성을 분리하기 위한 작업이다.
+     * 기존 공지사항을 수정한다.
+     *
+     * @param id 수정할 대상의 식별자
+     * @param request 수정 요청 데이터
+     * @return 204 No Content
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateNotice(
+            @PathVariable @Min(1) Long id,
+            @RequestBody @Valid UpdateNoticeRequest request) {
+        log.info("공지사항 수정 요청: id={}, title='{}'", id, request.title());
+
+        noticeService.updateNotice(id, toUpdateCommand(id, request));
+
+        log.info("공지사항 수정 완료: id={}", id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 공지사항을 삭제한다.
+     *
+     * @param id 삭제할 대상의 식별자
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNotice(@PathVariable @Min(1) Long id) {
+        log.info("공지사항 삭제 요청: id={}", id);
+
+        noticeService.deleteNotice(id);
+
+        log.info("공지사항 삭제 완료: id={}", id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /* 내부 변환 로직 (Mapping & URI) */
+    /* -------------------------------------------------------------------------- */
+
+    /**
+     * 리소스 접근을 위한 Location URI를 생성한다.
+     */
+    private static URI createLocationUri(Long noticeId) {
+        return ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(noticeId)
+                .toUri();
+    }
+
+    /**
+     * 등록 요청 DTO를 서비스용 Command 객체로 매핑한다.
      */
     private CreateNoticeCommand toCommand(CreateNoticeRequest request) {
         List<CreateNoticeCommand.AttachmentCommand> attachments =
-            Optional.ofNullable(request.attachments())
-                    .orElseGet(List::of) // null 안전성 확보
-                    .stream()
-                    .map(att -> new CreateNoticeCommand.AttachmentCommand(
-                            att.fileName(),
-                            att.storedPath(),
-                            att.fileSize()
-                    ))
-                    .toList();
+                Optional.ofNullable(request.attachments())
+                        .orElseGet(List::of) // null 안전성 확보
+                        .stream()
+                        .map(att -> new CreateNoticeCommand.AttachmentCommand(
+                                att.fileName(),
+                                att.storedPath(),
+                                att.fileSize()
+                        ))
+                        .toList();
 
         log.debug("첨부파일 변환 완료: {}개", attachments.size());
 
@@ -66,6 +114,33 @@ public class NoticeController {
                 request.title(),
                 request.content(),
                 request.author(),
+                request.noticeStartAt(),
+                request.noticeEndAt(),
+                attachments
+        );
+    }
+
+    /**
+     * 수정 요청 DTO를 서비스용 Command 객체로 매핑한다.
+     */
+    private UpdateNoticeCommand toUpdateCommand(Long id, UpdateNoticeRequest request) {
+        List<UpdateNoticeCommand.AttachmentCommand> attachments =
+                Optional.ofNullable(request.attachments())
+                        .orElseGet(List::of)
+                        .stream()
+                        .map(att -> new UpdateNoticeCommand.AttachmentCommand(
+                                att.fileName(),
+                                att.storedPath(),
+                                att.fileSize()
+                        ))
+                        .toList();
+
+        log.debug("공지사항[{}] 수정 첨부파일 변환 완료: {}개", id, attachments.size());
+
+        return new UpdateNoticeCommand(
+                id,
+                request.title(),
+                request.content(),
                 request.noticeStartAt(),
                 request.noticeEndAt(),
                 attachments

--- a/src/main/java/syboo/notice/notice/api/request/UpdateNoticeRequest.java
+++ b/src/main/java/syboo/notice/notice/api/request/UpdateNoticeRequest.java
@@ -1,0 +1,35 @@
+package syboo.notice.notice.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UpdateNoticeRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 500)
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        String content,
+
+        @NotNull(message = "공지 시작일은 필수입니다.")
+        LocalDateTime noticeStartAt,
+
+        @NotNull(message = "공지 종료일은 필수입니다.")
+        LocalDateTime noticeEndAt,
+
+        List<CreateNoticeRequest.AttachmentRequest> attachments
+) {
+        public record AttachmentRequest(
+                @NotBlank(message = "파일명은 필수입니다.")
+                String fileName,
+
+                @NotBlank(message = "저장 경로는 필수입니다.")
+                String storedPath,
+
+                long fileSize
+        ) {}
+}


### PR DESCRIPTION
## 🔎 작업 개요
- 공지사항 관리 API에서 **수정(Update)과 삭제(Delete) 기능 컨트롤러 메서드 추가**.
- 관련 **DTO (`UpdateNoticeRequest`) 추가**.
- 서비스 계층 로직은 이미 작성 및 테스트 완료, 이번 PR에서는 컨트롤러만 반영.
- 요청 진입/완료 시점 로그 기록, 첨부파일 변환 시 DEBUG 로그 추가.

## 🎯 관련 Issue
- Close #11

## 🧪 테스트
- [x] 단위 테스트 없음 (서비스 계층에서 테스트 완료)
- [x] 통합 테스트 작성 예정 (API 호출 검증)
- [x] 기존 테스트 통과 확인

## ⚙️ 주요 변경 사항
- `NoticeController`에 다음 엔드포인트 추가:
  - `PUT /api/notices/{id}` : 공지사항 수정
  - `DELETE /api/notices/{id}` : 공지사항 삭제
- `UpdateNoticeRequest` DTO 추가
- DTO → Command 변환 로직 포함
- Validation 적용(`@Valid`, `@Min(1)` 등)

설계상 의사결정 포인트:  
- 컨트롤러는 서비스 계층 로직 재사용, 중복 최소화  
- Optional 활용으로 null 안전성 확보  
- 로그 레벨: INFO(진입/완료), DEBUG(첨부파일 변환)

## 📌 리뷰 포인트
- DTO 구조 및 Command 변환 로직 적절성
- RESTful API 설계 준수 여부
- 현재는 예외 처리 구조 미흡, 추후 개선 예정

## ✅ 체크리스트
- [x] 테스트 코드 작성 없음 (서비스 계층에서 완료)
- [x] 기존 기능 영향 없음
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인
