### PR TITLE
[FEAT] 목록 조회 성능 개선을 위한 Notice 엔티티 역정규화(hasAttachment 추가)

### DIFF
--- a/src/main/java/syboo/notice/notice/api/NoticeController.java
+++ b/src/main/java/syboo/notice/notice/api/NoticeController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import syboo.notice.notice.api.request.CreateNoticeRequest;
@@ -21,6 +22,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/notices")
 @RequiredArgsConstructor
+@Validated
 public class NoticeController {
 
     private final NoticeService noticeService;
@@ -32,7 +34,8 @@ public class NoticeController {
      */
     @PostMapping
     public ResponseEntity<Long> createNotice(@RequestBody @Valid CreateNoticeRequest request) {
-        log.info("공지사항 등록 요청: title='{}', author='{}'", request.title(), request.author());
+        log.info("공지사항 등록 요청: title='{}', author='{}', hasFiles={}",
+                request.title(), request.author(), !request.attachments().isEmpty());
 
         Long noticeId = noticeService.createNotice(toCommand(request));
 

--- a/src/main/java/syboo/notice/notice/application/NoticeService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeService.java
@@ -36,6 +36,7 @@ public class NoticeService {
                 .noticeEndAt(command.getNoticeEndAt())
                 .build();
 
+        // 첨부파일 처리 (내부에서 notice.addAttachment 호출 시 hasAttachment가 true로 자동 갱신됨)
         processAttachments(command, notice);
 
         Notice savedNotice = noticeRepository.save(notice);
@@ -54,6 +55,7 @@ public class NoticeService {
         }
 
         for (CreateNoticeCommand.AttachmentCommand att : command.getAttachments()) {
+            // 추가될 때마다 hasAttachment = true 로 유지됨
             notice.addAttachment(
                     NoticeAttachment.builder()
                             .fileName(att.getFileName())
@@ -94,6 +96,7 @@ public class NoticeService {
                 command.getNoticeEndAt()
         );
 
+        // 첨부파일 교체 (removeAll 후 add 시점에 hasAttachment가 자동으로 false -> true/false로 동기화됨)
         updateAttachments(notice, command.getAttachments());
 
         log.info("공지사항 수정 완료: id={}", noticeId);
@@ -115,6 +118,7 @@ public class NoticeService {
 
         if (attachmentCommands != null && !attachmentCommands.isEmpty()) {
             for (UpdateNoticeCommand.AttachmentCommand att : attachmentCommands) {
+                // 추가될 때마다 hasAttachment = true 로 유지됨
                 notice.addAttachment(
                         NoticeAttachment.builder()
                                 .fileName(att.getFileName())

--- a/src/main/java/syboo/notice/notice/domain/Notice.java
+++ b/src/main/java/syboo/notice/notice/domain/Notice.java
@@ -43,6 +43,9 @@ public class Notice extends BaseEntity {
     @Column(nullable = false)
     private long viewCount = 0L;
 
+    @Column(nullable = false)
+    private boolean hasAttachment = false;
+
     @Version
     private Long version;
 
@@ -65,6 +68,7 @@ public class Notice extends BaseEntity {
         this.author = author;
         this.noticeStartAt = noticeStartAt;
         this.noticeEndAt = noticeEndAt;
+        this.hasAttachment = false;
     }
 
     public void update(
@@ -93,14 +97,24 @@ public class Notice extends BaseEntity {
     public void addAttachment(NoticeAttachment attachment) {
         attachments.add(attachment);
         attachment.assignNotice(this);
+        updateAttachmentStatus();
     }
 
     public void removeAttachment(NoticeAttachment attachment) {
         attachments.remove(attachment);
         attachment.assignNotice(null);
+        updateAttachmentStatus();
     }
 
     public void removeAllAttachments() {
         attachments.clear();
+        updateAttachmentStatus();
+    }
+
+    /**
+     * 첨부파일 리스트의 상태를 확인하여 hasAttachment 필드를 동기화한다.
+     */
+    private void updateAttachmentStatus() {
+        this.hasAttachment = !this.attachments.isEmpty();
     }
 }


### PR DESCRIPTION
## 🔎 작업 개요
목록 조회 성능 최적화를 위해 `Notice` 엔티티에 첨부파일 존재 여부를 관리하는 `hasAttachment` 필드를 추가하고, CUD 로직에서 이 상태가 자동 동기화되도록 개선했습니다.

## 🎯 관련 Issue
- Close #23 

## 🧪 테스트
- [x] 단위 테스트 추가 (첨부파일 추가/삭제 시 상태값 동기화 검증)
- [x] 통합 테스트 추가
- [x] 기존 테스트 통과 확인 (Dirty Checking 로직 유지 및 불필요한 Stubbing 제거)

## ⚙️ 주요 변경 사항
- **도메인(Notice):** `hasAttachment` 필드 추가 및 첨부파일 조작 메서드(`addAttachment`, `removeAllAttachments`) 내 상태 갱신 로직(`updateAttachmentStatus`) 캡슐화.
- **서비스(NoticeService):** 첨부파일 교체 로직(`updateAttachments`) 수행 시 도메인 메서드를 호출하여 상태값이 자동으로 DB에 반영되도록 구조화.
- **컨트롤러(NoticeController):** 가독성 향상을 위한 문서 주석 보완 및 `@PathVariable` 유효성 검사 강화.

## 📌 리뷰 포인트
- **도메인 캡슐화:** `hasAttachment` 필드를 외부 서비스 레이어에서 직접 수정하지 않고, `Notice` 엔티티 내부 메서드를 통해서만 변경되도록 설계했는데 정합성 측면에서 적절한지 확인 부탁드립니다.
- **테스트 코드:** Mockito 사용 시 불필요한 `save()` 스터빙을 제거하고 Dirty Checking을 검증하도록 수정했습니다.

## ✅ 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 영향 없음 (Dirty Checking 기반 동작 유지)
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인