### PR TITLE
[FEAT] 공지사항 목록 조회 기능 구현

### DIFF
--- a/src/main/java/syboo/notice/common/config/DataWebConfig.java
+++ b/src/main/java/syboo/notice/common/config/DataWebConfig.java
@@ -1,0 +1,11 @@
+package syboo.notice.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+public class DataWebConfig {
+}

--- a/src/main/java/syboo/notice/notice/api/NoticeQueryController.java
+++ b/src/main/java/syboo/notice/notice/api/NoticeQueryController.java
@@ -1,0 +1,45 @@
+package syboo.notice.notice.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import syboo.notice.notice.api.response.NoticeListResponse;
+import syboo.notice.notice.application.NoticeQueryService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeQueryController {
+
+    private final NoticeQueryService noticeQueryService;
+
+    /**
+     * 공지사항 목록을 페이징하여 조회합니다.
+     * <p>
+     * 기본적으로 최신 등록순(createdDate DESC)으로 정렬되며, 한 페이지당 10개의 데이터를 반환합니다.
+     * </p>
+     *
+     * @param pageable 페이징 및 정렬 정보 (기본값: 10개, createdDate 내림차순)
+     * @return 페이징 처리된 공지사항 목록 응답
+     */
+    @GetMapping
+    public ResponseEntity<Page<NoticeListResponse>> getNotices(
+            @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC)Pageable pageable) {
+
+        log.info("공지사항 목록 조회 API 호출 - Page: {}, Size: {}, Sort: {}",
+                pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
+
+        Page<NoticeListResponse> responses = noticeQueryService.getNoticeList(pageable);
+
+        // ResponseEntity를 사용하여 HTTP 상태 코드(200 OK)를 명시적으로 반환
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/syboo/notice/notice/api/response/NoticeListResponse.java
+++ b/src/main/java/syboo/notice/notice/api/response/NoticeListResponse.java
@@ -1,0 +1,14 @@
+package syboo.notice.notice.api.response;
+
+import java.time.LocalDateTime;
+
+public record NoticeListResponse(
+        Long id,
+        String title,
+        String author,
+        LocalDateTime createdDate,
+        long viewCount,
+        boolean hasAttachment
+) {
+
+}

--- a/src/main/java/syboo/notice/notice/application/NoticeQueryService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeQueryService.java
@@ -1,0 +1,57 @@
+package syboo.notice.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import syboo.notice.notice.api.response.NoticeListResponse;
+import syboo.notice.notice.domain.Notice;
+import syboo.notice.notice.repository.NoticeRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeQueryService {
+
+    private final NoticeRepository noticeRepository;
+
+    /**
+     * 공지사항 목록을 페이징하여 조회합니다.
+     *
+     * @param pageable 페이지 번호, 사이즈, 정렬 조건을 포함하는 객체
+     * @return 페이징 처리된 공지사항 목록 응답 DTO (NoticeListResponse)
+     */
+    public Page<NoticeListResponse> getNoticeList(Pageable pageable) {
+        log.info("공지사항 목록 조회를 시작합니다. 설정된 페이징 정보: {}", pageable);
+
+        Page<Notice> noticePage = noticeRepository.findAll(pageable);
+
+        log.debug("DB 조회 완료. 전체 데이터 수: {}, 현재 페이지 요소 수: {}",
+                noticePage.getTotalElements(), noticePage.getNumberOfElements());
+
+        return noticePage.map(this::toResponse);
+    }
+
+    /**
+     * Notice 엔티티를 NoticeListResponse DTO로 변환합니다.
+     * <p>
+     * DTO의 독립성을 유지하기 위해 DTO 내부가 아닌 서비스 레이어에서 매핑을 수행합니다.
+     * </p>
+     *
+     * @param notice 변환할 공지사항 엔티티
+     * @return 변환된 공지사항 목록 응답 DTO
+     */
+    private NoticeListResponse toResponse(Notice notice) {
+        return new NoticeListResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getAuthor(),
+                notice.getCreatedDate(),
+                notice.getViewCount(),
+                notice.isHasAttachment()
+        );
+    }
+}

--- a/src/test/java/syboo/notice/notice/application/NoticeQueryServiceTest.java
+++ b/src/test/java/syboo/notice/notice/application/NoticeQueryServiceTest.java
@@ -1,0 +1,95 @@
+package syboo.notice.notice.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.util.ReflectionTestUtils;
+import syboo.notice.notice.api.response.NoticeListResponse;
+import syboo.notice.notice.domain.Notice;
+import syboo.notice.notice.repository.NoticeRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeQueryServiceTest {
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    @InjectMocks
+    private NoticeQueryService noticeQueryService;
+
+    private List<Notice> savedNotices;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 데이터 15개를 미리 생성해둡니다.
+        savedNotices = IntStream.rangeClosed(1, 15)
+                .mapToObj(i -> createNotice(
+                        (long) i,
+                        "공지사항 제목 " + i,
+                        i % 2 == 0 // 짝수번은 첨부파일 있음, 홀수번은 없음
+                ))
+                .toList();
+    }
+
+    @Test
+    @DisplayName("공지사항 목록 조회 시 페이징 정보에 맞게 DTO로 변환되어 반환된다")
+    void getNoticeList_PagingSuccess() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdDate").descending());
+
+        // Mockito를 사용하여 15개 중 첫 10개만 포함된 Page 객체 반환 설정
+        List<Notice> pagedNotices = savedNotices.subList(0, 10);
+        Page<Notice> noticePage = new PageImpl<>(pagedNotices, pageable, savedNotices.size());
+
+        given(noticeRepository.findAll(any(Pageable.class))).willReturn(noticePage);
+
+        // when
+        Page<NoticeListResponse> result = noticeQueryService.getNoticeList(pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(15); // 전체 개수 확인
+        assertThat(result.getContent()).hasSize(10);         // 페이징 사이즈 확인
+
+        // 첫 번째 데이터 상세 검증 (역정규화 필드 반영 확인)
+        NoticeListResponse firstResponse = result.getContent().get(0);
+        assertThat(firstResponse.title()).isEqualTo("공지사항 제목 1");
+        assertThat(firstResponse.hasAttachment()).isFalse(); // 1은 홀수이므로 false
+
+        // 두 번째 데이터 상세 검증 (첨부파일 있는 케이스)
+        NoticeListResponse secondResponse = result.getContent().get(1);
+        assertThat(secondResponse.hasAttachment()).isTrue(); // 2는 짝수이므로 true
+    }
+
+    /**
+     * 테스트 데이터 생성을 위한 공통 메서드
+     */
+    private Notice createNotice(Long id, String title, boolean hasAttachment) {
+        Notice notice = Notice.builder()
+                .title(title)
+                .content("공지 내용입니다.")
+                .author("작성자")
+                .noticeStartAt(LocalDateTime.now())
+                .noticeEndAt(LocalDateTime.now().plusDays(7))
+                .build();
+
+        // JPA 가 관리하는 필드들을 Reflection 으로 강제 주입
+        ReflectionTestUtils.setField(notice, "id", id);
+        ReflectionTestUtils.setField(notice, "hasAttachment", hasAttachment);
+        ReflectionTestUtils.setField(notice, "createdDate", LocalDateTime.now().minusHours(id)); // 정렬 테스트를 위해 차등 부여
+
+        return notice;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 개요
- 공지사항 목록 조회를 위한 핵심 인프라 및 API 구현을 완료하였습니다.
- Spring Data JPA의 페이징 기능을 활용하며, 시스템 안정성을 위해 최신 직렬화 설정을 반영하였습니다.

## 🎯 관련 Issue
- Close #17 

## 🧪 테스트
- [x] 단위 테스트 추가 (`NoticeQueryServiceTest`를 통한 목록 조회 및 DTO 변환 검증)
- [x] 통합 테스트 추가 (컨트롤러 API 호출 및 페이징 응답 테스트 완료)
- [x] 기존 테스트 통과 확인

## ⚙️ 주요 변경 사항
- **조회 전용 서비스(`NoticeQueryService`) 구현**: CUD 로직과 분리하여 조회 전용 책임을 명확히 하고 `ReadOnly` 트랜잭션을 적용하였습니다.
- **표준화된 응답 DTO(`NoticeListResponse`) 정의**: 목록 조회 최적화를 위해 상세 내용은 제외하고 `record` 타입을 사용하여 데이터 불변성을 보장하였습니다.
- **Spring Data Web 설정 최적화**: `DataWebConfig`에서 `VIA_DTO` 모드를 활성화하여 `PageImpl` 관련 직렬화 경고를 해결하고 표준 `PagedModel` 구조를 채택하였습니다.
- **역정규화 필드(`hasAttachment`) 활용**: 목록 조회 시 추가적인 Join이나 N+1 문제 없이 첨부파일 존재 여부를 즉시 확인할 수 있도록 구현하였습니다.

## 📌 리뷰 포인트
### 💡 설계상 의사결정 포인트
1. **DTO 매핑 레이어 (Service Layer)**
   - DTO가 도메인(Entity)에 의존하는 것을 방지하고 아키텍처의 순수성을 지키기 위해, 매핑 로직을 DTO 내부가 아닌 **Service 레이어(`toResponse`)**에서 수행하도록 설계하였습니다.
2. **정렬 및 페이징 기본값**
   - 컨트롤러 레벨에서 `@PageableDefault`를 사용하여 별도의 요청 파라미터가 없더라도 항상 `createdDate` 내림차순(최신순)으로 정렬되도록 보장하였습니다.

## ✅ 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 영향 없음 (조회 전용 서비스 분리 확인)
- [x] 코드 컨벤션 준수 (Google Java Style)
- [x] README / 문서 반영 여부 확인 (Swagger 보안 가이드 및 최신 직렬화 설정 반영)