### PR TITLE
[FEAT] 공지사항 상세 조회 기능 구현

### DIFF
--- a/src/main/java/syboo/notice/notice/api/NoticeQueryController.java
+++ b/src/main/java/syboo/notice/notice/api/NoticeQueryController.java
@@ -8,8 +8,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import syboo.notice.notice.api.response.NoticeDetailResponse;
 import syboo.notice.notice.api.response.NoticeListResponse;
 import syboo.notice.notice.application.NoticeQueryService;
 
@@ -41,5 +43,17 @@ public class NoticeQueryController {
 
         // ResponseEntity를 사용하여 HTTP 상태 코드(200 OK)를 명시적으로 반환
         return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 공지사항 상세 정보를 조회합니다.
+     *
+     * @param id 공지사항 ID
+     * @return 공지사항 상세 정보
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<NoticeDetailResponse> getNotice(@PathVariable Long id) {
+        log.info("공지사항 상세 조회 API 호출 - ID: {}", id);
+        return ResponseEntity.ok(noticeQueryService.getNoticeDetail(id));
     }
 }

--- a/src/main/java/syboo/notice/notice/api/response/NoticeDetailResponse.java
+++ b/src/main/java/syboo/notice/notice/api/response/NoticeDetailResponse.java
@@ -1,0 +1,21 @@
+package syboo.notice.notice.api.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record NoticeDetailResponse(
+        Long id,
+        String title,
+        String content,
+        String author,
+        LocalDateTime createdDate,
+        long viewCount,
+        List<AttachmentResponse> attachments
+) {
+    public record AttachmentResponse(
+            Long id,
+            String fileName,
+            String storedPath,
+            long fileSize
+    ) {}
+}

--- a/src/main/java/syboo/notice/notice/application/NoticeQueryService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeQueryService.java
@@ -6,9 +6,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import syboo.notice.notice.api.response.NoticeDetailResponse;
 import syboo.notice.notice.api.response.NoticeListResponse;
 import syboo.notice.notice.domain.Notice;
 import syboo.notice.notice.repository.NoticeRepository;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -52,6 +55,45 @@ public class NoticeQueryService {
                 notice.getCreatedDate(),
                 notice.getViewCount(),
                 notice.isHasAttachment()
+        );
+    }
+
+    /**
+     * 공지사항 상세 정보를 조회합니다.
+     *
+     * @param id 조회할 공지사항 ID
+     * @return 공지사항 상세 응답 DTO
+     * @throws IllegalArgumentException 존재하지 않는 ID일 경우 발생
+     */
+    public NoticeDetailResponse getNoticeDetail(Long id) {
+        log.info("공지사항 상세 조회 요청 - ID: {}", id);
+
+        Notice notice = noticeRepository.findById(id)
+                .orElseThrow(() -> {
+                    log.warn("공지사항을 찾을 수 없습니다. ID: {}", id);
+                    return new IllegalArgumentException("해당 공지사항이 존재하지 않습니다. ID: " + id);
+                });
+
+        return toDetailResponse(notice);
+    }
+
+    private NoticeDetailResponse toDetailResponse(Notice notice) {
+        List<NoticeDetailResponse.AttachmentResponse> attachments = notice.getAttachments().stream()
+                .map(attachment -> new NoticeDetailResponse.AttachmentResponse(
+                        attachment.getId(),
+                        attachment.getFileName(),
+                        attachment.getStoredPath(),
+                        attachment.getFileSize()
+                )).toList();
+
+        return new NoticeDetailResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getAuthor(),
+                notice.getCreatedDate(),
+                notice.getViewCount(),
+                attachments
         );
     }
 }


### PR DESCRIPTION
## 🔎 작업 개요
- 특정 공지사항의 상세 정보 및 첨부파일 리스트 조회를 위한 상세 API 구현
- 유효하지 않은 ID 요청에 대한 예외 처리 로직 반영

## 🎯 관련 Issue
- Close #18 

## 🧪 테스트
- [x] 상세 조회 성공 케이스 단위 테스트 추가 (ID 존재 시 DTO 변환 및 데이터 정합성 검증)
- [x] 상세 조회 실패 케이스 단위 테스트 추가 (존재하지 않는 ID 조회 시 예외 발생 검증)
- [x] 기존 목록 조회 페이징 테스트 통과 확인

## ⚙️ 주요 변경 사항
- **NoticeDetailResponse DTO 정의**: 상세 내용(`content`) 및 첨부파일 리스트(`attachments`)를 포함하는 record 구조 설계
- **Service 레이어 상세 조회 로직 구현**: `findById` 기반 조회 및 `Optional.orElseThrow`를 활용한 예외 처리 적용
- **매핑 로직(`toDetailResponse`) 구현**: 엔티티 연관관계를 순회하며 중첩 DTO로 변환하는 로직 서비스 내 배치
- **Controller 엔드포인트 추가**: `GET /api/notices/{id}` 경로 매핑 및 `ResponseEntity` 반환 구조 적용

### 💡 설계상 의사결정 포인트
- **계층 간 독립성 유지**: DTO가 엔티티를 직접 알지 못하도록 서비스 레이어에서 매핑 책임을 가짐
- **NPE 방어 전략**: 테스트 코드 및 서비스 로직 내에서 첨부파일 리스트 초기화 및 null 체크를 통해 `NullPointerException` 사전 방지

## 📌 리뷰 포인트
- `NoticeDetailResponse` 내 첨부파일 정보 중 `storedPath` 노출이 보안 정책에 위배되지 않는지 확인 필요
- 존재하지 않는 ID 조회 시 발생하는 `IllegalArgumentException`의 메시지가 명확한지 검토

## ✅ 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 영향 없음
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인