### PR TITLE
Feature/notice query service

### DIFF
--- a/src/main/java/syboo/notice/notice/application/NoticeQueryService.java
+++ b/src/main/java/syboo/notice/notice/application/NoticeQueryService.java
@@ -74,8 +74,14 @@ public class NoticeQueryService {
      * @return 공지사항 상세 응답 DTO
      * @throws IllegalArgumentException 존재하지 않는 ID일 경우 발생
      */
+    @Transactional
     public NoticeDetailResponse getNoticeDetail(Long id) {
         log.info("공지사항 상세 조회 요청 - ID: {}", id);
+
+        // 조회수 증가
+        // ⚠️ 현재는 단일 DB 업데이트 방식
+        // 대규모 트래픽 환경에서는 Redis/벌크 업데이트 등 CQRS 분리 가능성을 고려
+        noticeRepository.updateViewCount(id);
 
         Notice notice = noticeRepository.findById(id)
                 .orElseThrow(() -> {

--- a/src/main/java/syboo/notice/notice/repository/NoticeRepository.java
+++ b/src/main/java/syboo/notice/notice/repository/NoticeRepository.java
@@ -1,7 +1,14 @@
 package syboo.notice.notice.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import syboo.notice.notice.domain.Notice;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long>, NoticeQueryRepository {
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Notice n set n.viewCount = n.viewCount + 1 where n.id = :id")
+    void updateViewCount(@Param("id") Long id);
 }

--- a/src/test/java/syboo/notice/notice/application/NoticeQueryServiceTest.java
+++ b/src/test/java/syboo/notice/notice/application/NoticeQueryServiceTest.java
@@ -16,6 +16,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -86,6 +87,8 @@ class NoticeQueryServiceTest {
         Long noticeId = 2L;
         Notice targetNotice = savedNotices.get(1);
 
+        ReflectionTestUtils.setField(targetNotice, "viewCount", 10L);
+
         // 첨부파일 강제 주입
         NoticeAttachment attachment = NoticeAttachment.builder()
                 .fileName("file1.txt")
@@ -104,6 +107,10 @@ class NoticeQueryServiceTest {
         assertThat(result.id()).isEqualTo(noticeId);
         assertThat(result.title()).isEqualTo("공지사항 제목 2");
         assertThat(result.content()).isEqualTo("공지 내용입니다.");
+
+        // 단위 테스트에서는 실제 DB 값이 안 변하므로 호출 여부가 가장 중요함
+        verify(noticeRepository, times(1)).updateViewCount(noticeId);
+
         assertThat(result.attachments()).hasSize(1);
         assertThat(result.attachments().get(0).fileName()).isEqualTo("file1.txt");
     }


### PR DESCRIPTION
## 🔎 작업 개요
- 공지사항 상세 조회 시 조회수를 증가시키는 로직 구현
- 대용량 트래픽 환경에서의 DB 부하를 최소화하기 위해 벌크 업데이트 방식 채택

## 🎯 관련 Issue
- close #20 
- Resolve #18

## 🧪 테스트
- [x] 단위 테스트 추가 (Mockito verify를 통한 벌크 연산 호출 검증)
- [ ] 통합 테스트 추가
- [x] 기존 테스트 통과 확인

## ⚙️ 주요 변경 사항
- **벌크 업데이트 방식을 통한 조회수 증가 최적화**
  - 엔티티의 Dirty Checking 방식 대신 `@Modifying` 벌크 쿼리를 사용하여 DB 락(Lock) 점유 시간 단축 및 성능 개선
  - `clearAutomatically = true` 옵션을 통해 벌크 연산 후 영속성 컨텍스트와 DB 간 불일치 문제 예방
- **상세 조회 비즈니스 로직 구현**
  - 상세 조회 요청 시 조회수 업데이트를 선행하여 사용자에게 최신 조회수 정보 제공
  - 예외 발생 시 로그 기록 및 `IllegalArgumentException`을 통한 예외 처리

## 📌 리뷰 포인트
- **대용량 트래픽 대응**: 현재는 DB 벌크 쿼리를 사용하나, 향후 트래픽 증가 시 Redis를 활용한 비동기 업데이트 방식으로 확장할 수 있도록 설계상 고려함 (CQRS 분리 가능성)
- **영속성 컨텍스트**: `updateViewCount` 호출 후 `findById` 시 `clearAutomatically` 설정으로 인한 데이터 정합성 보장 여부

## ✅ 체크리스트
- [x] 테스트 코드 작성 완료
- [x] 기존 기능 영향 없음
- [x] 코드 컨벤션 준수
- [ ] README / 문서 반영 여부 확인