### PR TITLE
Docs/api specification swagger

### DIFF
--- a/src/main/java/syboo/notice/common/config/SwaggerConfig.java
+++ b/src/main/java/syboo/notice/common/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package syboo.notice.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    // yml의 설정값을 동적으로 읽어온다.
+    @Value("${spring.servlet.multipart.max-file-size:10MB}")
+    private String maxFileSize;
+
+    @Value("${spring.servlet.multipart.max-request-size:50MB}")
+    private String maxRequestSize;
+
+    @Bean
+    public OpenAPI noticeOpenAPI() {
+        String description = """
+                공지사항 관리 및 첨부파일 기능을 제공하는 API 문서입니다.
+                
+                ### 주요 기능
+                - 공지사항 등록/수정/삭제/조회
+                - 다중 첨부파일 업로드 및 안전한 다운로드
+                - 조회수 중복 방지 및 동시성 처리
+                - 정렬 필드 유효성 검증
+                
+                **[파일 업로드 제한]**
+                - 개별 파일 최대: %s
+                - 전체 요청 최대: %s
+                """.formatted(maxFileSize, maxRequestSize);
+
+        return new OpenAPI()
+                .servers(List.of(new Server().url("http://localhost:8080").description("로컬 서버")))
+                .info(new Info()
+                        .title("Notice Service API")
+                        .description(description)
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/syboo/notice/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/syboo/notice/common/exception/GlobalExceptionHandler.java
@@ -4,12 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import syboo.notice.common.response.ErrorResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,8 +18,6 @@ import java.util.Map;
 @RestControllerAdvice // 전역 예외 처리기
 public class GlobalExceptionHandler {
 
-    public static final String ERROR = "error";
-    public static final String MESSAGE = "message";
     public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
     public static final String SERVER_ERROR_MESSAGE = "서버 이용 중 알 수 없는 오류가 발생했습니다. 관리자에게 문의하세요.";
 
@@ -27,166 +25,123 @@ public class GlobalExceptionHandler {
      * [400] @Valid 검증 실패 시 상세 메시지 반환
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<Map<String, Object>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.warn("입력값 검증 실패: {}", e.getBindingResult().getAllErrors().getFirst().getDefaultMessage());
-
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();
         e.getBindingResult().getFieldErrors().forEach(error ->
                 errors.put(error.getField(), error.getDefaultMessage()));
 
+        log.warn("입력값 검증 실패: {}", errors);
+
         return ResponseEntity
                 .badRequest()
-                .body(Map.of(
-                ERROR, "VALIDATION_FAILED",
-                "details", errors
-        ));
+                .body(ErrorResponse.of("VALIDATION_FAILED", errors));
     }
 
     /**
-     * [400] 비즈니스 로직 제약 조건 위반 (예: 공지 기간 역전)
+     * [400] 비즈니스 로직 제약 조건 위반 시 발생한다.
      */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("비즈니스 로직 위반 발생: {}", e.getMessage());
-
         return ResponseEntity
                 .badRequest()
-                .body(Map.of(
-                        ERROR, "INVALID_INPUT_VALUE",
-                        MESSAGE, e.getMessage()
-                ));
+                .body(ErrorResponse.of("INVALID_INPUT_VALUE", e.getMessage()));
     }
 
+    /**
+     * [400] 핸들러 메서드 유효성 검사 실패 시 발생한다.
+     */
     @ExceptionHandler(HandlerMethodValidationException.class)
-    public ResponseEntity<Map<String, String>> handleHandlerMethodValidationException(HandlerMethodValidationException ex) {
-        // 1. 서버 내부 로그에는 상세히 남김 (보안 이슈 없음)
-        log.warn("유효성 검사 실패 - 상세내용: {}", ex.getMessage());
-
-        String safeMessage = "입력 파라미터가 유효하지 않습니다.";
-
+    public ResponseEntity<ErrorResponse> handleHandlerMethodValidationException(HandlerMethodValidationException ex) {
+        log.warn("유효성 검사 실패: {}", ex.getMessage());
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of(
-                        ERROR, "INVALID_INPUT",
-                        MESSAGE, safeMessage
-                ));
+                .body(ErrorResponse.of("INVALID_INPUT", "입력 파라미터가 유효하지 않습니다."));
     }
 
     /**
-     *  [403] 보안 정책 위반 파일을 올렸을 경우
+     * [403] 보안 정책 위반 파일을 감지했을 때 발생한다.
      */
     @ExceptionHandler(FileSecurityException.class)
-    public ResponseEntity<Map<String, String>> handleFileSecurityException(FileSecurityException e) {
+    public ResponseEntity<ErrorResponse> handleFileSecurityException(FileSecurityException e) {
         log.warn("보안 정책 위반 파일 감지: {}", e.getMessage());
-
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
-                .body(Map.of(
-                        ERROR, "FILE_SECURITY_VIOLATION",
-                        MESSAGE, e.getMessage()
-                ));
+                .body(ErrorResponse.of("FILE_SECURITY_VIOLATION", e.getMessage()));
     }
 
     /**
-     * [404] 파일 자체가 존재하지 않거나 잘못된 경로일 경우
+     * [404] 리소스(공지사항, 파일 등)를 찾을 수 없을 때 발생한다.
      */
-    @ExceptionHandler(FileInvalidException.class)
-    public ResponseEntity<Map<String, String>> handleFileInvalidException(FileInvalidException e) {
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(Map.of(
-                        ERROR, "FILE_NOT_FOUND",
-                        MESSAGE, e.getMessage()
-                ));
-    }
-
-    /**
-     * [404] 리소스를 찾을 수 없는 경우 (조회/수정/삭제 대상 부재)
-     */
-    @ExceptionHandler(NoticeNotFoundException.class)
-    protected ResponseEntity<Map<String, Object>> handleNoticeNotFoundException(NoticeNotFoundException e) {
+    @ExceptionHandler({NoticeNotFoundException.class, FileInvalidException.class})
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(RuntimeException e) {
         log.warn("리소스 조회 실패: {}", e.getMessage());
-
+        String code = (e instanceof NoticeNotFoundException) ? "NOT_FOUND" : "FILE_NOT_FOUND";
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(Map.of(
-                        ERROR, "NOT_FOUND",
-                        MESSAGE, e.getMessage()
-                ));
+                .body(ErrorResponse.of(code, e.getMessage()));
     }
 
     /**
-     * [409] 동시성 수정 충돌 발생 시 (대용량 트래픽 고려)
+     * [409] 동시성 수정 충돌 발생 시 발생한다.
      */
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    protected ResponseEntity<Map<String, String>> handleOptimisticLockingFailureException(ObjectOptimisticLockingFailureException e) {
+    protected ResponseEntity<ErrorResponse> handleOptimisticLockingFailureException(ObjectOptimisticLockingFailureException e) {
         log.error("동시 수정 충돌 발생: {}", e.getMessage());
-
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
-                .body(Map.of(
-                        ERROR, "CONCURRENCY_CONFLICT",
-                        MESSAGE, "다른 사용자에 의해 수정된 데이터입니다. 새로고침 후 다시 시도해주세요."
-                ));
+                .body(ErrorResponse.of("CONCURRENCY_CONFLICT", "다른 사용자에 의해 수정된 데이터입니다. 새로고침 후 다시 시도해주세요."));
     }
 
     /**
-     * [413] 파일 용량 제한 초과
+     * [413] 파일 용량 제한을 초과했을 때 발생한다.
      */
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    protected ResponseEntity<Map<String, String>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+    protected ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         return ResponseEntity
                 .status(HttpStatus.CONTENT_TOO_LARGE)
-                .body(Map.of(
-                        ERROR, "FILE_TOO_LARGE",
-                        MESSAGE, "업로드 가능한 최대 파일 용량을 초과했습니다."
-                ));
+                .body(ErrorResponse.of("FILE_TOO_LARGE", "업로드 가능한 최대 파일 용량을 초과했습니다."));
     }
 
     /**
      * [500] 파일 저장 프로세스 중 물리적 오류 발생 (디스크 풀, 권한 부족 등)
-     * 이 예외는 서버 관리자의 확인이 필요한 중대한 사안입니다.
      */
     @ExceptionHandler(FileStorageException.class)
-    public ResponseEntity<Map<String, String>> handleFileStorageException(FileStorageException e) {
-        // 1. 관리자를 위한 로그
-        log.error("파일 시스템 물리적 오류 발생: ", e);
+    public ResponseEntity<ErrorResponse> handleFileStorageException(FileStorageException e) {
+        // 1. 관리자를 위한 상세 로그 (물리적 장애 상황)
+        log.error("파일 시스템 물리적 오류 발생 (시스템 점검 필요): ", e);
 
-        // 2. 사용자를 위한 응답
+        // 2. 사용자를 위한 응답 (보안상 상세 원인은 숨김)
         return ResponseEntity
                 .internalServerError()
-                .body(Map.of(
-                        ERROR, INTERNAL_SERVER_ERROR,
-                        MESSAGE, SERVER_ERROR_MESSAGE
-                ));
+                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR, SERVER_ERROR_MESSAGE));
     }
 
     /**
      * [500] 파일 처리 과정에서 발생한 일반적인 서버 내부 오류
      */
     @ExceptionHandler(FileException.class)
-    public ResponseEntity<Map<String, String>> handleFileException(FileException e) {
+    public ResponseEntity<ErrorResponse> handleFileException(FileException e) {
+        // 1. 비즈니스 로직 예외 로그
         log.warn("정의되지 않은 파일 예외 발생: {}", e.getMessage());
 
+        // 2. 사용자를 위한 응답
         return ResponseEntity
                 .internalServerError()
-                .body(Map.of(
-                        ERROR, INTERNAL_SERVER_ERROR,
-                        MESSAGE, SERVER_ERROR_MESSAGE
-                ));
+                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR, SERVER_ERROR_MESSAGE));
     }
 
     /**
      * [500] 그 외 예상치 못한 모든 서버 내부 오류
      */
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<Map<String, String>> handleException(Exception e) {
-        log.error("서버 내부 오류 발생: ", e); // 500 에러는 반드시 스택트레이스를 로그로 남겨야 함
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        // 1. 미처리 예외에 대한 추적용 로그
+        log.error("예상치 못한 서버 내부 오류 발생: ", e);
+
+        // 2. 사용자를 위한 응답
         return ResponseEntity
                 .internalServerError()
-                .body(Map.of(
-                ERROR, INTERNAL_SERVER_ERROR,
-                MESSAGE, SERVER_ERROR_MESSAGE
-        ));
+                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR, SERVER_ERROR_MESSAGE));
     }
 }

--- a/src/main/java/syboo/notice/common/response/ErrorResponse.java
+++ b/src/main/java/syboo/notice/common/response/ErrorResponse.java
@@ -1,0 +1,34 @@
+package syboo.notice.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.Map;
+
+@Schema(description = "공통 에러 응답 객체")
+@Builder
+public record ErrorResponse(
+        @Schema(description = "에러 코드 (대문자 스네이크 케이스)", example = "NOT_FOUND")
+        String error,
+
+        @Schema(description = "에러 메시지 (사용자용)", example = "해당 공지사항을 찾을 수 없습니다.")
+        String message,
+
+        @Schema(description = "상세 에러 정보 (필드 검증 실패 시 사용)", nullable = true)
+        Map<String, String> details
+) {
+    public static ErrorResponse of(String error, String message) {
+        return ErrorResponse.builder()
+                .error(error)
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse of(String error, Map<String, String> details) {
+        return ErrorResponse.builder()
+                .error(error)
+                .message("입력값 검증에 실패했습니다.")
+                .details(details)
+                .build();
+    }
+}

--- a/src/main/java/syboo/notice/notice/api/NoticeQueryController.java
+++ b/src/main/java/syboo/notice/notice/api/NoticeQueryController.java
@@ -1,5 +1,9 @@
 package syboo.notice.notice.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +21,7 @@ import syboo.notice.notice.api.response.NoticeDetailResponse;
 import syboo.notice.notice.api.response.NoticeListResponse;
 import syboo.notice.notice.application.NoticeQueryService;
 
+@Tag(name = "Notice Query API", description = "공지사항 목록 조회 및 상세 조회를 관리한다.")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -34,6 +39,10 @@ public class NoticeQueryController {
      * @param pageable 페이징 및 정렬 정보 (기본값: 10개, createdDate 내림차순)
      * @return 페이징 처리된 공지사항 목록 응답
      */
+    @Operation(summary = "공지사항 전체 목록 조회", description = "공지사항 목록을 페이징하여 조회한다. 기본적으로 최신 등록순으로 정렬된다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     @GetMapping
     public ResponseEntity<Page<NoticeListResponse>> getNotices(
             @PageableDefault(size = 10, sort = "createdDate", direction = Sort.Direction.DESC)Pageable pageable) {
@@ -51,6 +60,10 @@ public class NoticeQueryController {
      * 공지사항 검색 목록 조회 API
      * GET /api/notices/search?title=공지&startDate=2026-01-01T00:00:00...
      */
+    @Operation(summary = "공지사항 조건 검색", description = "검색어, 기간, 검색 타입을 기반으로 공지사항 목록을 검색한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 성공")
+    })
     @GetMapping("/search")
     public ResponseEntity<Page<NoticeListResponse>> search(
             NoticeSearchCondition condition,
@@ -66,6 +79,11 @@ public class NoticeQueryController {
      * @param id 공지사항 ID
      * @return 공지사항 상세 정보
      */
+    @Operation(summary = "공지사항 상세 조회", description = "ID를 통해 특정 공지사항의 상세 정보와 첨부파일 목록을 조회한다. 조회수 증가 로직이 포함되어 있다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 공지사항")
+    })
     @GetMapping("/{id}")
     public ResponseEntity<NoticeDetailResponse> getNotice(@PathVariable @Min(1) Long id) {
         log.info("공지사항 상세 조회 API 호출 - ID: {}", id);

--- a/src/main/java/syboo/notice/notice/api/request/CreateNoticeRequest.java
+++ b/src/main/java/syboo/notice/notice/api/request/CreateNoticeRequest.java
@@ -1,5 +1,6 @@
 package syboo.notice.notice.api.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -8,24 +9,30 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "공지사항 생성 요청 모델 (Multipart/form-data)")
 public record CreateNoticeRequest(
+        @Schema(description = "공지사항 제목", example = "신규 기능 업데이트 안내")
         @NotBlank(message = "제목은 필수입니다.")
         @Size(max = 500, message = "제목은 최대 500자까지 입력 가능합니다.")
         String title,
 
+        @Schema(description = "공지사항 상세 내용", example = "이번 업데이트를 통해 성능이 20% 향상되었습니다.")
         @NotBlank(message = "내용은 필수입니다.")
         String content,
 
+        @Schema(description = "작성자 성함/ID", example = "관리자")
         @NotBlank(message = "작성자는 필수입니다.")
         String author,
 
+        @Schema(description = "공지 게시 시작 일시 (ISO-8601)", example = "2026-01-26T00:00:00")
         @NotNull(message = "공지 시작일은 필수입니다.")
         LocalDateTime noticeStartAt,
 
+        @Schema(description = "공지 게시 종료 일시 (ISO-8601)", example = "2026-12-31T23:59:59")
         @NotNull(message = "공지 종료일은 필수입니다.")
         LocalDateTime noticeEndAt,
 
+        @Schema(description = "첨부파일 리스트 (다중 파일 업로드 가능)", type = "string", format = "binary")
         List<MultipartFile> attachments
 ) {
 }
-

--- a/src/main/java/syboo/notice/notice/api/request/NoticeSearchCondition.java
+++ b/src/main/java/syboo/notice/notice/api/request/NoticeSearchCondition.java
@@ -1,11 +1,20 @@
 package syboo.notice.notice.api.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "공지사항 검색 조건")
 public record NoticeSearchCondition(
+        @Schema(description = "검색어 (제목 또는 내용에 포함된 단어, 앞뒤 공백은 자동으로 제거됨)", example = "업데이트")
         String query,
+
+        @Schema(description = "검색 타입 (TITLE: 제목 검색, TITLE_CONTENT: 제목+내용 통합 검색)", example = "TITLE_CONTENT")
         String searchType,
+
+        @Schema(description = "조회 시작일 (등록일 기준)", example = "2026-01-01T00:00:00")
         LocalDateTime startDate,
+
+        @Schema(description = "조회 종료일 (등록일 기준)", example = "2026-01-26T23:59:59")
         LocalDateTime endDate
 ) {
     // 생성자에서 trim() 처리

--- a/src/main/java/syboo/notice/notice/api/request/UpdateNoticeRequest.java
+++ b/src/main/java/syboo/notice/notice/api/request/UpdateNoticeRequest.java
@@ -1,5 +1,6 @@
 package syboo.notice.notice.api.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -8,23 +9,29 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "공지사항 수정 요청 모델 (Multipart/form-data)")
 public record UpdateNoticeRequest(
+        @Schema(description = "수정할 제목", example = "[(수정)] 2026년 상반기 채용 일정 변경")
         @NotBlank(message = "제목은 필수입니다.")
         @Size(max = 500)
         String title,
 
+        @Schema(description = "수정할 내용", example = "기존 일정에서 일주일 연기되었습니다.")
         @NotBlank(message = "내용은 필수입니다.")
         String content,
 
+        @Schema(description = "공지 게시 시작 일시", example = "2026-01-26T00:00:00")
         @NotNull(message = "공지 시작일은 필수입니다.")
         LocalDateTime noticeStartAt,
 
+        @Schema(description = "공지 게시 종료 일시", example = "2026-12-31T23:59:59")
         @NotNull(message = "공지 종료일은 필수입니다.")
         LocalDateTime noticeEndAt,
 
+        @Schema(description = "새롭게 추가할 첨부파일 리스트", type = "string", format = "binary")
         List<MultipartFile> newAttachments,
 
-        // 2. 유지할 기존 파일들의 ID 리스트 (이 리스트에 없는 기존 파일은 삭제 처리)
+        @Schema(description = "유지할 기존 첨부파일 ID 리스트 (이 리스트에 없는 기존 파일은 삭제 처리됨)", example = "[1, 2, 5]")
         List<Long> remainAttachmentIds
 ) {
 }

--- a/src/main/java/syboo/notice/notice/api/response/FileDownloadResponse.java
+++ b/src/main/java/syboo/notice/notice/api/response/FileDownloadResponse.java
@@ -1,12 +1,18 @@
 package syboo.notice.notice.api.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.core.io.Resource;
 
 /**
  * 첨부파일 다운로드 요청에 대한 응답 데이터를 담는 객체
  */
+@Schema(description = "첨부파일 다운로드 응답 모델")
 public record FileDownloadResponse(
+
+        @Schema(description = "원본 파일명", example = "project_plan.pdf")
         String originFileName,
+
+        @Schema(description = "파일 리소스 (바이너리 데이터)", hidden = true)
         Resource resource
 ) {
 

--- a/src/main/java/syboo/notice/notice/api/response/NoticeDetailResponse.java
+++ b/src/main/java/syboo/notice/notice/api/response/NoticeDetailResponse.java
@@ -1,21 +1,44 @@
 package syboo.notice.notice.api.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(description = "공지사항 상세 조회 응답")
 public record NoticeDetailResponse(
+        @Schema(description = "공지사항 ID", example = "1")
         Long id,
+
+        @Schema(description = "제목", example = "2026년 상반기 신입 사원 채용 공고")
         String title,
+
+        @Schema(description = "내용", example = "자세한 사항은 첨부파일을 확인해 주세요.")
         String content,
+
+        @Schema(description = "작성자", example = "인사팀")
         String author,
+
+        @Schema(description = "등록 일시")
         LocalDateTime createdDate,
+
+        @Schema(description = "조회수", example = "128")
         long viewCount,
+
+        @Schema(description = "첨부파일 목록")
         List<AttachmentResponse> attachments
 ) {
+    @Schema(description = "공지사항 첨부파일 정보")
     public record AttachmentResponse(
+            @Schema(description = "파일 ID", example = "10")
             Long id,
+
+            @Schema(description = "원본 파일명", example = "recruit_guide.pdf")
             String originFileName,
+
+            @Schema(description = "파일 크기 (Byte 단위)", example = "1024576")
             long fileSize,
+
+            @Schema(description = "파일 확장자/타입", example = "application/pdf")
             String contentType
     ) {}
 }

--- a/src/main/java/syboo/notice/notice/api/response/NoticeListResponse.java
+++ b/src/main/java/syboo/notice/notice/api/response/NoticeListResponse.java
@@ -1,14 +1,26 @@
 package syboo.notice.notice.api.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
+@Schema(description = "공지사항 목록 조회 응답 (요약 정보)")
 public record NoticeListResponse(
+        @Schema(description = "공지사항 ID", example = "1")
         Long id,
+
+        @Schema(description = "제목", example = "2026년 설 연휴 고객센터 휴무 안내")
         String title,
+
+        @Schema(description = "작성자", example = "운영팀")
         String author,
+
+        @Schema(description = "등록 일시")
         LocalDateTime createdDate,
+
+        @Schema(description = "조회수", example = "350")
         long viewCount,
+
+        @Schema(description = "첨부파일 존재 여부", example = "true")
         boolean hasAttachment
 ) {
-
 }


### PR DESCRIPTION
## 🔎 작업 개요
- SpringDoc OpenAPI(Swagger)를 도입하여 API 명세 자동화 및 시각화를 완료했음.
- 각 엔드포인트의 비즈니스 로직과 에러 응답 규격을 명시하여 문서 품질을 높였음.

## 🎯 관련 Issue
- Close #39 

## 🧪 테스트
- [x] 단위 테스트 추가 (Swagger 설정 로딩 확인)
- [x] 통합 테스트 통과 확인
- [x] Swagger UI(/swagger-ui/index.html) 접속 및 API 동작 테스트 완료

## ⚙️ 주요 변경 사항
- **Swagger 전역 설정 도입**: `application.yml`의 파일 용량 제한 설정을 동적으로 읽어 가이드에 표시하도록 `SwaggerConfig` 구현함.
- **공통 에러 응답 규격화**: `ErrorResponse` DTO를 `common.response` 패키지에 신설하고 `GlobalExceptionHandler`에서 이를 반환하도록 수정하여 에러 스키마를 명세함.
- **바이너리 데이터 시각화**: 파일 업로드/다운로드 API에 `MediaType.MULTIPART_FORM_DATA_VALUE` 및 `application/octet-stream` 설정을 적용하여 Swagger UI에서 실제 파일 선택 및 다운로드가 가능하도록 개선함.

## 📌 리뷰 포인트
- **`SwaggerConfig`**: `Text Block("""")`과 `.formatted()`를 활용한 동적 가이드 메시지 생성 로직이 적절한지 확인 바람.
- **`NoticeController`**: 파일 업로드 필드(`attachments`)가 Swagger UI에서 바이너리 선택창으로 정상 노출되는지 확인 필요함.
- **`GlobalExceptionHandler`**: 기존 `Map` 기반 응답에서 `ErrorResponse` DTO 기반으로의 전환이 모든 예외 케이스에 누락 없이 반영되었는지 검토 바람.

## ✅ 체크리스트
- [x] 기존 기능 영향 없음 (비즈니스 로직 수정 없이 명세만 추가함)
- [x] 코드 컨벤션 준수
- [x] README / 문서 반영 여부 확인